### PR TITLE
X-Ray exporter implementation

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.4.3"
+version = "3.5.1"
 
 runner.dialect = scala213
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,10 +39,10 @@ lazy val `xray-udp-exporter` =
     .settings(
       name := "trace4cats-xray-udp-exporter",
       libraryDependencies ++= Seq(
-        Dependencies.circeGeneric,
+        Dependencies.circeCore,
         Dependencies.fs2Io,
-        Dependencies.trace4catsModel,
         Dependencies.trace4catsKernel,
+        Dependencies.trace4catsModel,
         Dependencies.trace4catsExporterCommon
       )
     )

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayExceptionId.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayExceptionId.scala
@@ -1,0 +1,62 @@
+package io.janstenpickle.trace4cats.xray
+
+import cats.effect.kernel.Sync
+import cats.effect.std.Random
+import cats.syntax.functor._
+import cats.syntax.show._
+import cats.{Eq, Functor, Show}
+import org.apache.commons.codec.binary.Hex
+
+import scala.util.Try
+
+case class XRayExceptionId private (value: Array[Byte]) extends AnyVal {
+  override def toString: String = show"XRayExceptionId($this)"
+}
+
+object XRayExceptionId {
+  val size = 8
+
+  trait Gen[F[_]] {
+    def gen: F[XRayExceptionId]
+  }
+
+  object Gen extends GenInstances0 {
+    def apply[F[_]](implicit ev: Gen[F]): Gen[F] = ev
+
+    def from[F[_]](f: F[XRayExceptionId]): Gen[F] = new Gen[F] {
+      def gen: F[XRayExceptionId] = f
+    }
+  }
+
+  trait GenInstances0 extends GenInstances1 {
+    implicit def fromRandomTraceIdGen[F[_]: Functor: Random]: Gen[F] =
+      Gen.from(Random[F].nextBytes(size).map(XRayExceptionId.unsafe))
+  }
+
+  trait GenInstances1 { this: GenInstances0 =>
+    implicit def threadLocalRandomTraceIdGen[F[_]: Sync]: Gen[F] = {
+      implicit val rnd: Random[F] = Random.javaUtilConcurrentThreadLocalRandom[F]
+      fromRandomTraceIdGen[F]
+    }
+  }
+
+  def gen[F[_]: Gen]: F[XRayExceptionId] = Gen[F].gen
+
+  def fromHexString(hex: String): Option[XRayExceptionId] =
+    Try(Hex.decodeHex(hex)).toOption.flatMap(apply)
+
+  def apply(array: Array[Byte]): Option[XRayExceptionId] =
+    if (array.length == size) Some(new XRayExceptionId(array)) else None
+
+  def unsafe(array: Array[Byte]): XRayExceptionId =
+    apply(array).getOrElse(
+      throw new IllegalArgumentException(s"Expected a byte-array of size $size, got ${array.length}")
+    )
+
+  val invalid: XRayExceptionId = new XRayExceptionId(Array.fill(size)(0))
+
+  implicit val show: Show[XRayExceptionId] =
+    Show.show(tid => Hex.encodeHexString(tid.value))
+
+  implicit val eq: Eq[XRayExceptionId] = Eq.by(_.show)
+}

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpan.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpan.scala
@@ -54,7 +54,7 @@ private[xray] object XRayUdpSpan {
     * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
     */
   private def toEpochSeconds(i: Instant): Double =
-    ChronoUnit.MICROS.between(Instant.EPOCH, i).toDouble / 1000_000
+    ChronoUnit.MICROS.between(Instant.EPOCH, i).toDouble / 1000000
 
   private def spanStatusFaultJson[F[_]: Applicative: XRayExceptionId.Gen](status: SpanStatus): F[JsonObject] =
     XRayExceptionId.gen[F].map { id =>

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpan.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpan.scala
@@ -1,0 +1,167 @@
+package io.janstenpickle.trace4cats.xray
+
+import cats.{Applicative, Eval, Functor, Monad}
+import cats.data.NonEmptyList
+import cats.effect.{Clock, Ref}
+import cats.effect.std.Random
+import cats.syntax.applicative._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.show._
+import cats.syntax.traverse._
+import fs2.Chunk
+import io.circe.{Encoder, Json, JsonObject, Printer}
+import io.circe.syntax._
+import io.janstenpickle.trace4cats.`export`.SemanticTags
+import io.janstenpickle.trace4cats.model._
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import scala.util.matching.Regex
+
+private[xray] object XRayUdpSpan {
+
+  /** Span names can contain Unicode letters, numbers, and whitespace, and a limited set of symbols.
+    *
+    * See the `name` documentation under "Required Segment Fields"
+    * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
+    */
+  private val nameRegex: Regex = """[^\p{L}0-9 _\.:/%&#=\+\-@]""".r
+
+  /** Annotation keys must be alphanumeric in order to work with filters. Underscore is allowed. Other symbols and
+    * whitespace are not allowed.
+    *
+    * See the documentation under "Annotations"
+    * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-annotations
+    */
+  private val keyRegex: Regex = """[^A-Za-z0-9_]""".r
+
+  private implicit val attributeValueEncoder: Encoder[AttributeValue] = Encoder.instance {
+    case AttributeValue.StringValue(value) => Json.fromString(value.value)
+    case AttributeValue.BooleanValue(value) => Json.fromBoolean(value.value)
+    case AttributeValue.LongValue(value) => Json.fromLong(value.value)
+    case AttributeValue.DoubleValue(value) => Json.fromDoubleOrString(value.value)
+    case value: AttributeValue.AttributeList => Json.fromString(value.show)
+  }
+
+  private val statusTags = SemanticTags.statusTags("span.")
+
+  /** The time the segment was created/closed, in floating point seconds in epoch time. Microsecond resolution is
+    * recommended when available.
+    *
+    * See the `start_time` and `end_time` documentation under "Required Segment Fields"
+    * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
+    */
+  private def toEpochSeconds(i: Instant): Double =
+    ChronoUnit.MICROS.between(Instant.EPOCH, i).toDouble / 1000000
+
+  private def randomHexString[F[_]: Functor: Random](bytes: Int): F[String] =
+    Random[F]
+      .nextBytes(bytes)
+      .map(x => BigInt(1, x).toString(16).reverse.padTo(bytes * 2, '0').reverse)
+
+  /** An X-Ray trace ID consists of
+    *   - The version, that is, 1
+    *   - The time of the original request, in Unix epoch time, in 8 hexadecimal digits
+    *   - A 96-bit identifier for the trace, globally unique, in 24 hexadecimal digits
+    *
+    * See the `trace_id` documentation under "Required Segment Fields"
+    * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
+    */
+  private def xrayTraceId[F[_]: Applicative: Clock: Random]: F[String] =
+    (Clock[F].realTime, randomHexString[F](12)).mapN { (t, r) =>
+      s"1-${t.toSeconds.toHexString}-$r"
+    }
+
+  private def exceptionId[F[_]: Functor: Random]: F[String] =
+    randomHexString[F](8)
+
+  private def spanStatusFaultJson[F[_]: Applicative: Random](status: SpanStatus): F[JsonObject] =
+    exceptionId[F].map { id =>
+      JsonObject(
+        "fault" := true,
+        "cause" := Json.obj(
+          "exceptions" := Json.arr(
+            Json.obj(
+              "id" := id,
+              "message" := Some(status).collect { case SpanStatus.Internal(msg) => msg },
+              "type" := status.entryName
+            )
+          )
+        )
+      )
+    }
+
+  private def spanStatusJson[F[_]: Applicative: Random](status: SpanStatus): F[JsonObject] =
+    status match {
+      case SpanStatus.Ok => JsonObject.empty.pure[F]
+      case _ => spanStatusFaultJson[F](status)
+    }
+
+  private def jsonToChunk(j: Json): Chunk[Byte] =
+    Chunk.byteBuffer(Printer.noSpaces.printToByteBuffer(j))
+
+  private def json[F[_]: Monad: Random](
+    process: Option[TraceProcess],
+    span: CompletedSpan,
+    traceId: String,
+    childSpans: Ref[F, Map[TraceId, NonEmptyList[CompletedSpan]]]
+  ): F[JsonObject] = {
+    val (badName: Option[String], goodName: String) =
+      if (nameRegex.findFirstMatchIn(span.name).isDefined)
+        (Some(span.name), nameRegex.replaceAllIn(span.name, "_"))
+      else
+        (None, span.name)
+
+    val (badKeys: Map[String, AttributeValue], goodKeys: Map[String, AttributeValue]) =
+      (process.fold(Map.empty[String, AttributeValue])(_.attributes) ++ span.allAttributes ++ statusTags(
+        span.status
+      ) ++ SemanticTags.kindTags(span.kind)).partition { case (k, _) =>
+        keyRegex.findFirstMatchIn(k).isDefined
+      }
+
+    val fixedAnnotations = badKeys.map { case (k, v) =>
+      keyRegex.replaceAllIn(k, "_") -> v
+    }
+    val allAnnotations: Map[String, AttributeValue] =
+      goodKeys ++
+        badName.map(n => "malformed_name" -> AttributeValue.StringValue(Eval.now(n))) ++
+        (if (badKeys.nonEmpty)
+           Map("malformed_keys" -> AttributeValue.StringValue(Eval.now(badKeys.keys.mkString(","))))
+         else
+           Map.empty) ++
+        fixedAnnotations
+
+    (
+      spanStatusJson[F](span.status),
+      childSpans
+        .modify(m => (m - span.context.traceId, m.get(span.context.traceId)))
+        .flatMap(_.traverse(_.traverse(json[F](process, _, traceId, childSpans))))
+    ).mapN { (statusJson, children) =>
+      JsonObject(
+        "name" := goodName,
+        "id" := span.context.spanId.show,
+        "trace_id" := traceId,
+        "parent_id" := span.context.parent.map(_.spanId.show),
+        "start_time" := toEpochSeconds(span.start),
+        "end_time" := toEpochSeconds(span.end),
+        "annotations" := allAnnotations.asJson,
+        "subsegments" := children
+      ).deepMerge(statusJson)
+    }
+  }
+
+  val jsonHeader = jsonToChunk(Json.obj("format" := "json", "version" := 1))
+
+  def jsonChunk[F[_]: Monad: Clock: Random](
+    process: Option[TraceProcess],
+    span: CompletedSpan,
+    childSpans: Ref[F, Map[TraceId, NonEmptyList[CompletedSpan]]]
+  ): F[Chunk[Byte]] =
+    xrayTraceId[F].flatMap { traceId =>
+      json[F](process, span, traceId, childSpans).map { jsonObj =>
+        jsonToChunk(Json.fromJsonObject(jsonObj).deepDropNullValues)
+      }
+    }
+}

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpan.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpan.scala
@@ -2,7 +2,7 @@ package io.janstenpickle.trace4cats.xray
 
 import cats.{Applicative, Eval, Functor, Monad}
 import cats.data.NonEmptyList
-import cats.effect.{Clock, Ref}
+import cats.effect.kernel.{Clock, Ref}
 import cats.effect.std.Random
 import cats.syntax.applicative._
 import cats.syntax.apply._
@@ -54,7 +54,7 @@ private[xray] object XRayUdpSpan {
     * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
     */
   private def toEpochSeconds(i: Instant): Double =
-    ChronoUnit.MICROS.between(Instant.EPOCH, i).toDouble / 1000000
+    ChronoUnit.MICROS.between(Instant.EPOCH, i).toDouble / 1000_000
 
   private def randomHexString[F[_]: Functor: Random](bytes: Int): F[String] =
     Random[F]

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpanCompleter.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpanCompleter.scala
@@ -1,23 +1,24 @@
 package io.janstenpickle.trace4cats.xray
 
 import cats.effect.kernel.{Async, Resource}
+import cats.effect.std.Random
+import com.comcast.ip4s._
 import fs2.Chunk
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, QueuedSpanCompleter}
 import io.janstenpickle.trace4cats.kernel.SpanCompleter
 import io.janstenpickle.trace4cats.model.TraceProcess
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object XRayUdpSpanCompleter {
-  def apply[F[_]: Async](
+  def apply[F[_]: Async: Random](
     process: TraceProcess,
-    host: String = "localhost",
-    port: Int = 2000,
+    host: Host = XRayUdpSpanExporter.defaultHost,
+    port: Port = XRayUdpSpanExporter.defaultPort,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
-      Resource
-        .eval(XRayUdpSpanExporter[F, Chunk](host, port))
+      XRayUdpSpanExporter[F, Chunk](Some(process), host, port)
         .flatMap(QueuedSpanCompleter[F](process, _, config))
     }
 }

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpanExporter.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpanExporter.scala
@@ -1,9 +1,79 @@
 package io.janstenpickle.trace4cats.xray
 
 import cats.Foldable
-import cats.effect.kernel.Async
+import cats.data.NonEmptyList
+import cats.effect.{Async, Deferred, Ref, Resource}
+import cats.effect.std.Random
+import cats.syntax.applicative._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import com.comcast.ip4s._
+import fs2.Chunk
+import fs2.io.net.{Datagram, Network}
 import io.janstenpickle.trace4cats.kernel.SpanExporter
+import io.janstenpickle.trace4cats.model.{Batch, CompletedSpan, TraceId, TraceProcess}
+import java.nio.charset.StandardCharsets
 
 object XRayUdpSpanExporter {
-  def apply[F[_]: Async, G[_]: Foldable](host: String = "localhost", port: Int = 2000): F[SpanExporter[F, G]] = ???
+  val defaultHost: Host = Option(System.getenv("XRAY_AGENT_HOST"))
+    .flatMap(Host.fromString)
+    .getOrElse(ip"127.0.0.1")
+
+  val defaultPort: Port = Option(System.getenv("XRAY_AGENT_PORT"))
+    .flatMap(Port.fromString)
+    .getOrElse(port"2000")
+
+  private val newLine = Chunk.array("\n".getBytes(StandardCharsets.UTF_8))
+
+  private def resolveIp[F[_]: Async](host: Host, ipRef: Deferred[F, IpAddress]): F[IpAddress] =
+    ipRef.tryGet.flatMap {
+      case Some(ip) => ip.pure[F]
+      case None => host.resolve[F].flatTap(ipRef.complete)
+    }
+
+  def apply[F[_]: Async: Random, G[_]: Foldable](
+    process: Option[TraceProcess],
+    host: Host = defaultHost,
+    port: Port = defaultPort
+  ): Resource[F, SpanExporter[F, G]] =
+    /** Initialize a `Ref` to hold a map of `TraceId` to `NonEmptyList[CompletedSpan]`. Spans with a parent will be
+      * accumulated in this map and eventually exported along with their parent.
+      */
+    (Network[F].openDatagramSocket(), Resource.eval(Ref.of[F, Map[TraceId, NonEmptyList[CompletedSpan]]](Map.empty)))
+      .mapN { (socket, childSpans) =>
+        new SpanExporter[F, G] {
+          def sendSpan(ipRef: Deferred[F, IpAddress], span: CompletedSpan): F[Unit] =
+            (resolveIp[F](host, ipRef), XRayUdpSpan.jsonChunk[F](process, span, childSpans)).tupled
+              .flatMap { case (ip, chunk) =>
+                socket.write(Datagram(SocketAddress(ip, port), XRayUdpSpan.jsonHeader ++ newLine ++ chunk))
+              }
+
+          override def exportBatch(batch: Batch[G]): F[Unit] =
+            /** Initialize a `Deferred` to hold the target `IpAddress` so we only need to resolve it at most once for
+              * each call to `exportBatch`
+              */
+            Deferred[F, IpAddress].flatMap { ipRef =>
+              batch.spans.traverse_ { span =>
+                span.context.parent match {
+                  /** If the span has a parent, just store it in our `childSpans` reference */
+                  case Some(_) =>
+                    childSpans.update { m =>
+                      m.updated(
+                        span.context.traceId,
+                        m.get(span.context.traceId) match {
+                          case Some(children) => span :: children
+                          case None => NonEmptyList.one(span)
+                        }
+                      )
+                    }
+
+                  /** If the span doesn't have a parent, export it and all of its children */
+                  case None =>
+                    sendSpan(ipRef, span)
+                }
+              }
+            }
+        }
+      }
 }

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpanExporter.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/XRayUdpSpanExporter.scala
@@ -2,7 +2,7 @@ package io.janstenpickle.trace4cats.xray
 
 import cats.Foldable
 import cats.data.NonEmptyList
-import cats.effect.{Async, Deferred, Ref, Resource}
+import cats.effect.kernel.{Async, Deferred, Ref, Resource}
 import cats.effect.std.Random
 import cats.syntax.applicative._
 import cats.syntax.apply._
@@ -13,6 +13,7 @@ import fs2.Chunk
 import fs2.io.net.{Datagram, Network}
 import io.janstenpickle.trace4cats.kernel.SpanExporter
 import io.janstenpickle.trace4cats.model.{Batch, CompletedSpan, TraceId, TraceProcess}
+
 import java.nio.charset.StandardCharsets
 
 object XRayUdpSpanExporter {

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/compat/XRayCompatInstances.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/compat/XRayCompatInstances.scala
@@ -1,0 +1,18 @@
+package io.janstenpickle.trace4cats.xray.compat
+
+import cats.Apply
+import cats.effect.kernel.{Clock, Sync}
+import cats.effect.std.Random
+import io.janstenpickle.trace4cats.model.TraceId
+
+trait XRayCompatInstances0 extends XRayCompatInstances1 {
+  implicit def fromRandomClockXRayTraceIdGen[F[_]: Apply: Random: Clock]: TraceId.Gen[F] =
+    explicits.xRayTraceIdGen[F]
+}
+
+trait XRayCompatInstances1 {
+  implicit def fromSyncXRayTraceIdGen[F[_]: Sync]: TraceId.Gen[F] = {
+    implicit val rnd: Random[F] = Random.javaUtilConcurrentThreadLocalRandom[F]
+    explicits.xRayTraceIdGen[F]
+  }
+}

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/compat/explicits.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/compat/explicits.scala
@@ -1,0 +1,44 @@
+package io.janstenpickle.trace4cats.xray.compat
+
+import cats.{Apply, Show}
+import cats.effect.kernel.Clock
+import cats.effect.std.Random
+import cats.syntax.apply._
+import io.janstenpickle.trace4cats.model.TraceId
+import org.apache.commons.codec.binary.Hex
+
+import java.nio.ByteBuffer
+
+object explicits {
+
+  /** Generates an X-Ray `trace_id` based on `Clock[F]` and `Random[F]`:
+    *   1. the first 4 bytes are epoch time;
+    *   1. the rest bytes are random.
+    */
+  def xRayTraceIdGen[F[_]: Apply: Random: Clock]: TraceId.Gen[F] = TraceId.Gen.from {
+    val timeSize = Integer.BYTES
+    val rndSize = TraceId.size - timeSize
+    (Clock[F].realTime, Random[F].nextBytes(rndSize)).mapN { (t, r) =>
+      val bytes = ByteBuffer.allocate(TraceId.size).putInt(t.toSeconds.toInt).put(r).array
+      TraceId.unsafe(bytes)
+    }
+  }
+
+  /** Encodes an X-Ray `trace_id` as 3 hyphen-separated tokens:
+    *   1. the version, that is, 1;
+    *   1. the time of the original request, in Unix epoch time, in 8 hexadecimal digits;
+    *   1. a 96-bit identifier for the trace, globally unique, in 24 hexadecimal digits.
+    *
+    * See documentation under
+    * [[https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields "Required Segment Fields"]].
+    */
+  val xRayTraceIdExportShow: Show[TraceId] = Show.show { traceId =>
+    val timeSize = Integer.BYTES
+    val rndSize = TraceId.size - timeSize
+    val bytes = traceId.value
+    val t = new String(Hex.encodeHex(bytes, 0, timeSize, true))
+    val r = new String(Hex.encodeHex(bytes, timeSize, rndSize, true))
+    s"1-$t-$r"
+  }
+
+}

--- a/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/compat/package.scala
+++ b/modules/xray-udp-exporter/src/main/scala/io/janstenpickle/trace4cats/xray/compat/package.scala
@@ -1,0 +1,3 @@
+package io.janstenpickle.trace4cats.xray
+
+package object compat extends XRayCompatInstances0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   lazy val trace4catsKernel = "io.janstenpickle"         %% "trace4cats-kernel"          % Versions.trace4cats
   lazy val trace4catsModel = "io.janstenpickle"          %% "trace4cats-model"           % Versions.trace4cats
 
-  lazy val circeGeneric = "io.circe" %% "circe-generic" % Versions.circe
-  lazy val fs2Io = "co.fs2"          %% "fs2-io"        % Versions.fs2
+  lazy val circeCore = "io.circe" %% "circe-core" % Versions.circe
+  lazy val fs2Io = "co.fs2"       %% "fs2-io"     % Versions.fs2
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.8"
     val scala3 = "3.1.1"
 
-    val trace4cats = "0.13.1"
+    val trace4cats = "0.13.1+20-973c3271"
 
     val circe = "0.14.1"
     val fs2 = "3.2.7"


### PR DESCRIPTION
Closes trace4cats/trace4cats-xray#3 and trace4cats/trace4cats#118.

Adds initial implementation of an exporter that sends spans to AWS X-Ray. Some notes and questions:

- I'm using `fs2.io.net.DatagramSocket` for writing to the UDP socket, but I'm open to changing this if there's a different library you'd prefer
- X-Ray annotation keys can't have periods, so the keys used by `SemanticTags.<kind|status>Tags` aren't valid. For now I've just replaced periods with underscores
- I'm not sure what the best way is to write tests for the exporter. Unfortunately [LocalStack's X-Ray support](https://docs.localstack.cloud/aws/xray-tracing/) requires LocalStack Pro, so maybe the best option would be to use [fs2's `DatagramSocket#reads`](https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.13/3.1.0/fs2-io_2.13-3.1.0-javadoc.jar/!/fs2/io/net/DatagramSocket.html#reads:fs2.Stream[F,fs2.io.net.Datagram]) to verify that data is sent properly?